### PR TITLE
Remove -o:none info which does not work for odin check

### DIFF
--- a/src/main/java/com/lasagnerd/odin/sdkConfig/OdinSdkSettingsComponent.java
+++ b/src/main/java/com/lasagnerd/odin/sdkConfig/OdinSdkSettingsComponent.java
@@ -53,7 +53,6 @@ public class OdinSdkSettingsComponent {
                 .addComponentToRightColumn(createLabel(
                         "Optional. Space separated build flags passed to 'odin check'.<br><br>" +
                                 "Useful flags:<ul>" +
-                                "<li>-o:none (for fastest compile times)</li>" +
                                 "<li>-vet -vet-cast -strict-style (for more checks)</li>" +
                                 "<li>-max-error-count:999 (to report more errors)</li>" +
                                 "</ul>"), 0)


### PR DESCRIPTION
Also, there is no `develop` branch anymore 😉 

![CleanShot 2024-08-14 at 20 17 20@2x](https://github.com/user-attachments/assets/db6c6182-69d2-488c-bb41-fa8a09f9c375)
