### PR TITLE
Make publishing token file optional for ./gradlew buildPlugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,8 +32,11 @@ intellijPlatform  {
     }
 
     publishing {
-        val myToken = File("certificate/token").readText()
-        token.set(myToken)
+        val tokenFile = File("certificate/token")
+        if (tokenFile.exists()) {
+            val myToken = tokenFile.readText()
+            token.set(myToken)
+        }
     }
 
     signing {


### PR DESCRIPTION
Makes it easier to test for others (like me) who do not have a token file. Since, currently, I always comment it out.