### PR TITLE
Use <br> to separate error tooltip on lines

### DIFF
--- a/src/main/java/com/lasagnerd/odin/codeInsight/annotators/buildErrorsAnnotator/OdinBuildErrorsExternalAnnotator.java
+++ b/src/main/java/com/lasagnerd/odin/codeInsight/annotators/buildErrorsAnnotator/OdinBuildErrorsExternalAnnotator.java
@@ -66,7 +66,7 @@ public class OdinBuildErrorsExternalAnnotator extends ExternalAnnotator<PsiFile,
                     isWarning ? CodeInsightColors.WARNINGS_ATTRIBUTES : CodeInsightColors.ERRORS_ATTRIBUTES;
 
             String message = error.getMsgs().getFirst();
-            String tooltip = String.join("\n", error.getMsgs());
+            String tooltip = String.join("<br>", error.getMsgs());
             holder.newAnnotation(severity, message)
                     .tooltip(tooltip)
                     .range(errorRange)


### PR DESCRIPTION
The `\n` does not work for the error tooltip, but `<br>` does.

![CleanShot 2024-08-15 at 16 07 33@2x](https://github.com/user-attachments/assets/86cc932c-75b2-4d34-ac34-4c4b79b6df12)
