### PR TITLE
Replace trove with fastutil HashMap

### DIFF
--- a/src/main/java/com/lasagnerd/odin/lang/OdinParserUtil.java
+++ b/src/main/java/com/lasagnerd/odin/lang/OdinParserUtil.java
@@ -7,17 +7,17 @@ import com.intellij.psi.TokenType;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.TokenSet;
 import com.lasagnerd.odin.lang.psi.OdinTypes;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.coverage.gnu.trove.TObjectIntHashMap;
 
 import java.util.Stack;
 
 @SuppressWarnings("unused")
 public class OdinParserUtil extends GeneratedParserUtilBase {
 
-    private static final Key<TObjectIntHashMap<String>> MODES_KEY = Key.create("MODES_KEY");
-    private static final Key<Stack<TObjectIntHashMap<String>>> MODES_STACK_KEY = Key.create("MODES_STACK_KEY");
+    private static final Key<Object2IntOpenHashMap<String>> MODES_KEY = Key.create("MODES_KEY");
+    private static final Key<Stack<Object2IntOpenHashMap<String>>> MODES_STACK_KEY = Key.create("MODES_STACK_KEY");
 
     public static boolean afterClosingBrace(PsiBuilder builder, int level) {
         IElementType tokenType = lookBehindUntilNoWhitespace(builder);
@@ -52,9 +52,9 @@ public class OdinParserUtil extends GeneratedParserUtilBase {
 
     public static boolean enterNoBlockMode(PsiBuilder builder, int level) {
         // Save all current flags on a stack
-        TObjectIntHashMap<String> flags = getParsingModes(builder);
-        TObjectIntHashMap<String> flagsCopy = new TObjectIntHashMap<>(flags);
-        Stack<TObjectIntHashMap<String>> stack = builder.getUserData(MODES_STACK_KEY);
+        Object2IntOpenHashMap<String> flags = getParsingModes(builder);
+        Object2IntOpenHashMap<String> flagsCopy = new Object2IntOpenHashMap<>(flags);
+        Stack<Object2IntOpenHashMap<String>> stack = builder.getUserData(MODES_STACK_KEY);
 
         if (stack == null) {
             stack = new Stack<>();
@@ -65,59 +65,56 @@ public class OdinParserUtil extends GeneratedParserUtilBase {
         // Clear all flags
         flags.clear();
 
-        flags.put("NO_BLOCK", flags.get("NO_BLOCK") + 1);
+        flags.put("NO_BLOCK", flags.getInt("NO_BLOCK") + 1);
         return true;
 
     }
 
     public static boolean isModeOff(PsiBuilder builder, int level, String mode) {
-        TObjectIntHashMap<String> flags = getParsingModes(builder);
-        return flags.get(mode) <= 0;
+        Object2IntOpenHashMap<String> flags = getParsingModes(builder);
+        return flags.getInt(mode) <= 0;
     }
 
     public static boolean exitNoBlockMode(PsiBuilder builder, int level) {
         // Restore all flags from the stack
-        TObjectIntHashMap<String> flags = getParsingModes(builder);
-        Stack<TObjectIntHashMap<String>> stack = builder.getUserData(MODES_STACK_KEY);
+        Object2IntOpenHashMap<String> flags = getParsingModes(builder);
+        Stack<Object2IntOpenHashMap<String>> stack = builder.getUserData(MODES_STACK_KEY);
         if(stack != null && !stack.isEmpty()) {
-            TObjectIntHashMap<String> flagsCopy = stack.pop();
+            Object2IntOpenHashMap<String> flagsCopy = stack.pop();
             flags.clear();
-            flagsCopy.forEachEntry((key, value) -> {
-                flags.put(key, value);
-                return true;
-            });
+			flags.putAll(flagsCopy);
         }
         return true;
     }
 
     public static boolean enterMode(PsiBuilder builder, int level, String mode) {
-        TObjectIntHashMap<String> flags = getParsingModes(builder);
-        flags.put(mode, flags.get(mode) + 1);
+        Object2IntOpenHashMap<String> flags = getParsingModes(builder);
+        flags.put(mode, flags.getInt(mode) + 1);
         return true;
     }
 
     public static boolean exitMode(PsiBuilder builder, int level, String mode) {
-        TObjectIntHashMap<String> flags = getParsingModes(builder);
+        Object2IntOpenHashMap<String> flags = getParsingModes(builder);
 
-        flags.put(mode, flags.get(mode) - 1);
+        flags.put(mode, flags.getInt(mode) - 1);
 
-        if (flags.get(mode) <= 0) {
-            flags.remove(mode);
+        if (flags.getInt(mode) <= 0) {
+            flags.removeInt(mode);
         }
         return true;
     }
 
     public static boolean isModeOn(PsiBuilder builder, int level, String mode) {
-        TObjectIntHashMap<String> flags = getParsingModes(builder);
+        Object2IntOpenHashMap<String> flags = getParsingModes(builder);
 
-        return flags.get(mode) > 0;
+        return flags.getInt(mode) > 0;
     }
 
 
     @NotNull
-    private static TObjectIntHashMap<String> getParsingModes(@NotNull PsiBuilder builder_) {
-        TObjectIntHashMap<String> flags = builder_.getUserData(MODES_KEY);
-        if (flags == null) builder_.putUserData(MODES_KEY, flags = new TObjectIntHashMap<>());
+    private static Object2IntOpenHashMap<String> getParsingModes(@NotNull PsiBuilder builder_) {
+        Object2IntOpenHashMap<String> flags = builder_.getUserData(MODES_KEY);
+        if (flags == null) builder_.putUserData(MODES_KEY, flags = new Object2IntOpenHashMap<>());
         return flags;
     }
 


### PR DESCRIPTION
When opening the plugin in CLion 2024.2 I encountered this `NoClassDefFoundError`:

<details>
  <summary>java.lang.ClassNotFoundException: org.jetbrains.coverage.gnu.trove.TObjectHashingStrategy</summary>

    ```
    java.lang.NoClassDefFoundError: org/jetbrains/coverage/gnu/trove/TObjectHashingStrategy
	at com.lasagnerd.odin.lang.OdinParser.procedureDefinition(OdinParser.java:2667)
	at com.lasagnerd.odin.lang.OdinParser.procedureDeclarationStatement(OdinParser.java:2627)
	at com.lasagnerd.odin.lang.OdinParser.fileScopeStatement(OdinParser.java:1620)
	at com.lasagnerd.odin.lang.OdinParser.fileScopeStatementList_0(OdinParser.java:1652)
	at com.lasagnerd.odin.lang.OdinParser.fileScopeStatementList(OdinParser.java:1640)
	at com.lasagnerd.odin.lang.OdinParser.fileScope(OdinParser.java:1581)
	at com.lasagnerd.odin.lang.OdinParser.odinFile(OdinParser.java:2414)
	at com.lasagnerd.odin.lang.OdinParser.parse_root_(OdinParser.java:36)
	at com.lasagnerd.odin.lang.OdinParser.parse_root_(OdinParser.java:32)
	at com.lasagnerd.odin.lang.OdinParser.parseLight(OdinParser.java:27)
	at com.lasagnerd.odin.lang.OdinParser.parse(OdinParser.java:19)
	at com.intellij.psi.tree.ILazyParseableElementType.doParseContents(ILazyParseableElementType.java:60)
	at com.intellij.psi.tree.IFileElementType.parseContents(IFileElementType.java:38)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.lambda$ensureParsed$2(LazyParseableElement.java:183)
	at com.intellij.psi.impl.DebugUtil.performPsiModification(DebugUtil.java:535)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.ensureParsed(LazyParseableElement.java:182)
	at com.intellij.psi.impl.source.tree.LazyParseableElement.getFirstChildNode(LazyParseableElement.java:234)
	at com.intellij.psi.impl.source.tree.CompositeElement.findLeafElementAt(CompositeElement.java:121)
	at com.intellij.psi.impl.source.tree.CompositeElement.findLeafElementAt(CompositeElement.java:33)
	at com.intellij.psi.AbstractFileViewProvider.findElementAt(AbstractFileViewProvider.java:233)
	at com.intellij.psi.AbstractFileViewProvider.findElementAt(AbstractFileViewProvider.java:206)
	at com.intellij.xml.breadcrumbs.PsiFileBreadcrumbsCollector.findFirstBreadcrumbedElement(PsiFileBreadcrumbsCollector.java:217)
	at com.intellij.xml.breadcrumbs.PsiFileBreadcrumbsCollector.findStartElement(PsiFileBreadcrumbsCollector.java:175)
	at com.intellij.xml.breadcrumbs.PsiFileBreadcrumbsCollector.computePsiElements(PsiFileBreadcrumbsCollector.java:109)
	at com.intellij.openapi.editor.impl.stickyLines.StickyLinesCollector.collectLines(StickyLinesCollector.kt:96)
	at com.intellij.codeInsight.stickyLines.StickyLinesPass.doCollectInformation(StickyLinesPass.kt:23)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:57)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:418)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.runWithSpanIgnoreThrows(trace.kt:118)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceUtil.runWithSpanThrows(TraceUtil.java:36)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$3(PassExecutorService.java:413)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.tryRunReadAction(AnyThreadWriteThreadingSupport.kt:291)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:965)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$4(PassExecutorService.java:404)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$13(CoreProgressManager.java:660)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:735)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:691)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:659)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:79)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:403)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:379)
	at com.intellij.openapi.fileTypes.impl.FileTypeManagerImpl.cacheFileTypesInside(FileTypeManagerImpl.java:802)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$1(PassExecutorService.java:379)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.executeByImpatientReader(AnyThreadWriteThreadingSupport.kt:486)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:179)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:377)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:190)
	at java.base/java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:507)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1491)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:2073)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:2035)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:187)
Caused by: java.lang.ClassNotFoundException: org.jetbrains.coverage.gnu.trove.TObjectHashingStrategy PluginClassLoader(plugin=PluginDescriptor(name=Odin Support, id=com.lasagnerd.odin, descriptorPath=plugin.xml, path=~/Projects/misc/odin-intellij/build/idea-sandbox/CL-2024.2/plugins/odin-intellij, version=0.5.2, package=null, isBundled=false), packagePrefix=null, state=active, parents=PluginDescriptor(name=IDEA CORE, id=com.intellij, moduleName=intellij.platform.vcs.impl, descriptorPath=intellij.platform.vcs.impl.xml, path=~/.gradle/caches/8.9/transforms/dc2d49e1578ebbb82de46674ed8db11d/transformed/CLion-2024.2/lib, version=242.20224.384, package=null, isBundled=true), PluginDescriptor(name=IDEA CORE, id=com.intellij, moduleName=intellij.platform.vcs.log.impl, descriptorPath=intellij.platform.vcs.log.impl.xml, path=~/.gradle/caches/8.9/transforms/dc2d49e1578ebbb82de46674ed8db11d/transformed/CLion-2024.2/lib, version=242.20224.384, package=null, isBundled=true), PluginDescriptor(name=IDEA CORE, id=com.intellij, moduleName=intellij.platform.vcs.dvcs.impl, descriptorPath=intellij.platform.vcs.dvcs.impl.xml, path=~/.gradle/caches/8.9/transforms/dc2d49e1578ebbb82de46674ed8db11d/transformed/CLion-2024.2/lib, version=242.20224.384, package=null, isBundled=true), PluginDescriptor(name=IDEA CORE, id=com.intellij, moduleName=intellij.platform.collaborationTools, descriptorPath=intellij.platform.collaborationTools.xml, path=~/.gradle/caches/8.9/transforms/dc2d49e1578ebbb82de46674ed8db11d/transformed/CLion-2024.2/lib, version=242.20224.384, package=null, isBundled=true), PluginDescriptor(name=Native Debugging Support, id=com.intellij.nativeDebug, descriptorPath=plugin.xml, path=~/.gradle/caches/8.9/transforms/dc2d49e1578ebbb82de46674ed8db11d/transformed/CLion-2024.2/plugins/nativeDebug-plugin, version=242.20224.384, package=null, isBundled=true), )
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClass(PluginClassLoader.kt:157)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 53 more

    ```

</details>

Seems like trove4j is obsolete. Replacing `TObjectIntHashMap` with fastutil `Object2IntOpenHashMap` seems to work. (But not sure if this is the most optimal alternative.)
