### PR TITLE
WIP: Debug support using clion cidr

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,9 @@ version = pluginVersion
 
 repositories {
     mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 // Configure Gradle IntelliJ Plugin
@@ -70,24 +73,21 @@ sourceSets.main.get().java.srcDirs("src/main/gen")
 dependencies {
     implementation("org.projectlombok:lombok:1.18.34")
     intellijPlatform {
-        intellijIdeaCommunity("2024.2")
+        //intellijIdeaCommunity("2024.2")
+        //intellijIdeaUltimate("2024.2")
+        clion("2024.2")
         pluginVerifier()
         zipSigner()
         instrumentationTools()
+
+        plugin("com.intellij.nativeDebug:242.21829.3")
+
         testFramework(TestFrameworkType.Platform)
 
         testImplementation("junit:junit:4.13.2")
         testCompileOnly ("org.junit.jupiter:junit-jupiter-api:5.4.2")
     }
 }
-
-repositories {
-    mavenCentral()
-    intellijPlatform {
-        defaultRepositories()
-    }
-}
-
 
 kotlin {
     jvmToolchain(21)

--- a/src/main/java/com/lasagnerd/odin/debugger/OdinDebugRunParameters.java
+++ b/src/main/java/com/lasagnerd/odin/debugger/OdinDebugRunParameters.java
@@ -1,0 +1,40 @@
+package com.lasagnerd.odin.debugger;
+
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.openapi.util.NlsSafe;
+import com.jetbrains.cidr.execution.Installer;
+import com.jetbrains.cidr.execution.RunParameters;
+import com.jetbrains.cidr.execution.TrivialInstaller;
+import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriverConfiguration;
+import com.jetbrains.cidr.execution.debugger.backend.gdb.GDBDriverConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class OdinDebugRunParameters extends RunParameters {
+
+	GeneralCommandLine commandLine;
+
+	public OdinDebugRunParameters(GeneralCommandLine commandLine) {
+		this.commandLine = commandLine;
+	}
+
+	@Override
+	public @NotNull Installer getInstaller() {
+		return new TrivialInstaller(commandLine);
+	}
+
+	@Override
+	public @NotNull DebuggerDriverConfiguration getDebuggerDriverConfiguration() {
+		return new GDBDriverConfiguration() {
+			@Override
+			public @NotNull @NlsSafe String getDriverName() {
+				return "Odin GDB";
+			}
+		};
+	}
+
+	@Override
+	public @Nullable String getArchitectureId() {
+		return "";
+	}
+}

--- a/src/main/java/com/lasagnerd/odin/debugger/OdinDebuggerEditorsExtension.java
+++ b/src/main/java/com/lasagnerd/odin/debugger/OdinDebuggerEditorsExtension.java
@@ -1,0 +1,32 @@
+package com.lasagnerd.odin.debugger;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.xdebugger.XSourcePosition;
+import com.intellij.xdebugger.evaluation.EvaluationMode;
+import com.jetbrains.cidr.execution.debugger.CidrDebuggerEditorsExtensionBase;
+import com.lasagnerd.odin.lang.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class OdinDebuggerEditorsExtension extends CidrDebuggerEditorsExtensionBase {
+	@Override
+	protected @Nullable PsiElement getContext(@NotNull Project project, @NotNull XSourcePosition sourcePosition) {
+		PsiElement context = super.getContext(project, sourcePosition);
+		return ancestorOrSelf(context, OdinStatement.class);
+	}
+
+	@Override
+	protected @NotNull PsiFile createExpressionCodeFragment(@NotNull Project project, @NotNull String text, @NotNull PsiElement context, @NotNull EvaluationMode mode) {
+		return super.createExpressionCodeFragment(project, text, context, mode);
+	}
+
+	/**
+	 * Finds the nearest ancestor of a specified type, including the element itself.
+	 */
+	private @Nullable <T extends PsiElement> T ancestorOrSelf(@Nullable PsiElement element, @NotNull Class<T> cls) {
+		return PsiTreeUtil.getParentOfType(element, cls, false);
+	}
+}

--- a/src/main/java/com/lasagnerd/odin/debugger/OdinDebuggerLanguageSupport.java
+++ b/src/main/java/com/lasagnerd/odin/debugger/OdinDebuggerLanguageSupport.java
@@ -1,0 +1,24 @@
+package com.lasagnerd.odin.debugger;
+
+import com.intellij.execution.configurations.RunProfile;
+import com.intellij.xdebugger.evaluation.XDebuggerEditorsProvider;
+import com.jetbrains.cidr.execution.debugger.CidrDebuggerEditorsProvider;
+import com.jetbrains.cidr.execution.debugger.CidrDebuggerLanguageSupport;
+import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriver;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+public class OdinDebuggerLanguageSupport extends CidrDebuggerLanguageSupport {
+
+	@Override
+	public @NotNull Set<DebuggerDriver.DebuggerLanguage> getSupportedDebuggerLanguages() {
+		return Set.of(DebuggerDriver.StandardDebuggerLanguage.C);
+	}
+
+	@Override
+	public @Nullable XDebuggerEditorsProvider createEditor(@Nullable RunProfile profile) {
+		return new CidrDebuggerEditorsProvider();
+	}
+}

--- a/src/main/java/com/lasagnerd/odin/debugger/OdinLineBreakpointFileTypesProvider.java
+++ b/src/main/java/com/lasagnerd/odin/debugger/OdinLineBreakpointFileTypesProvider.java
@@ -1,0 +1,16 @@
+package com.lasagnerd.odin.debugger;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.jetbrains.cidr.execution.debugger.breakpoints.CidrLineBreakpointFileTypesProvider;
+import com.lasagnerd.odin.lang.OdinFileType;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class OdinLineBreakpointFileTypesProvider implements CidrLineBreakpointFileTypesProvider {
+	private static final Set<FileType> ODIN_FILE_TYPES = Collections.singleton(OdinFileType.INSTANCE);
+	@Override
+	public Set<FileType> getFileTypes() {
+		return ODIN_FILE_TYPES;
+	}
+}

--- a/src/main/java/com/lasagnerd/odin/debugger/OdinLocalDebugProcess.java
+++ b/src/main/java/com/lasagnerd/odin/debugger/OdinLocalDebugProcess.java
@@ -1,0 +1,21 @@
+package com.lasagnerd.odin.debugger;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.filters.Filter;
+import com.intellij.execution.filters.TextConsoleBuilder;
+import com.intellij.xdebugger.XDebugSession;
+import com.jetbrains.cidr.execution.RunParameters;
+import com.jetbrains.cidr.execution.debugger.CidrLocalDebugProcess;
+import org.jetbrains.annotations.NotNull;
+
+public class OdinLocalDebugProcess extends CidrLocalDebugProcess {
+
+	public OdinLocalDebugProcess(@NotNull RunParameters parameters, @NotNull XDebugSession session, @NotNull TextConsoleBuilder consoleBuilder) throws ExecutionException {
+		super(parameters, session, consoleBuilder, (project) -> Filter.EMPTY_ARRAY, false);
+	}
+
+	@Override
+	public boolean isLibraryFrameFilterSupported() {
+		return false;
+	}
+}

--- a/src/main/java/com/lasagnerd/odin/debugger/OdinNativeDebugProgramRunner.java
+++ b/src/main/java/com/lasagnerd/odin/debugger/OdinNativeDebugProgramRunner.java
@@ -1,0 +1,71 @@
+package com.lasagnerd.odin.debugger;
+
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.configurations.RunnerSettings;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.filters.TextConsoleBuilder;
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
+import com.intellij.execution.process.ProcessTerminatedListener;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.GenericProgramRunner;
+import com.intellij.psi.search.ExecutionSearchScopes;
+import com.intellij.xdebugger.XDebugProcess;
+import com.intellij.xdebugger.XDebugProcessStarter;
+import com.intellij.xdebugger.XDebugSession;
+import com.intellij.xdebugger.XDebuggerManager;
+import org.jetbrains.annotations.NotNull;
+
+public class OdinNativeDebugProgramRunner extends GenericProgramRunner<RunnerSettings> {
+
+	@Override
+	public @NotNull String getRunnerId() {
+		return "OdinNativeDebugProgramRunner";
+	}
+
+
+	@Override
+	public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
+		return DefaultDebugExecutor.EXECUTOR_ID.equals(executorId); // && profile instanceof OdinRunConfiguration // needed ? will this be called for non odin files/projects?
+	}
+
+
+	@Override
+	protected void execute(@NotNull ExecutionEnvironment environment, @NotNull RunProfileState state) {
+		// ./odin build ../odin-test/ -debug
+		GeneralCommandLine commandLine = new GeneralCommandLine();
+		commandLine = commandLine
+				.withExePath(environment.getProject().getBasePath() + "/bin/" + "odin-test")
+				.withRedirectErrorStream(true);
+
+//				val commandLine = cmd
+//				.withExePath(exe.absolutePath)
+//				.withWorkDirectory(workingDir)
+//				.withCharset(Charsets.UTF_8)
+//				.withRedirectErrorStream(true)
+
+		TextConsoleBuilder consoleBuilder = TextConsoleBuilderFactory.getInstance().createBuilder(environment.getProject(), ExecutionSearchScopes.executionScope(environment.getProject(), environment.getRunProfile()));
+
+		OdinDebugRunParameters runParameters = new OdinDebugRunParameters(commandLine);
+
+		XDebuggerManager debuggerManager = XDebuggerManager.getInstance(environment.getProject());
+		try {
+			debuggerManager.startSessionAndShowTab("Odin Debugger", null, new XDebugProcessStarter() {
+
+				@Override
+				public @NotNull XDebugProcess start(@NotNull XDebugSession session) throws ExecutionException {
+					OdinLocalDebugProcess debugProcess = new OdinLocalDebugProcess(runParameters, session, consoleBuilder);
+					ProcessTerminatedListener.attach(debugProcess.getProcessHandler(), environment.getProject());
+					debugProcess.start();
+					 return debugProcess;
+				}
+			}).getRunContentDescriptor();
+		} catch (ExecutionException e) {
+			throw new RuntimeException(e);
+		}
+
+	}
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -111,6 +111,7 @@
   ]]></description>
 
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="native-debug-support.xml">com.intellij.nativeDebug</depends>
 
     <extensions defaultExtensionNs="com.intellij">
 
@@ -140,6 +141,9 @@
                         serviceImplementation="com.lasagnerd.odin.codeInsight.imports.OdinImportServiceImpl"/>
         <configurationType implementation="com.lasagnerd.odin.runConfiguration.OdinRunConfigurationType"
                            id="OdinRunConfigurationType"/>
+        <!--debug-->
+        <programRunner implementation="com.lasagnerd.odin.debugger.OdinNativeDebugProgramRunner"/>
+
         <runConfigurationProducer implementation="com.lasagnerd.odin.runConfiguration.OdinLazyConfigurationProducer"/>
         <runLineMarkerContributor language="Odin"
                                   implementationClass="com.lasagnerd.odin.runConfiguration.OdinRunLineMarkerContributor"/>
@@ -202,6 +206,12 @@
             <className>com.lasagnerd.odin.codeInsight.refactor.OdinSpecifyTypeIntention</className>
             <category>Refactor</category>
         </intentionAction>
+    </extensions>
+
+    <extensions defaultExtensionNs="cidr.debugger">
+        <languageSupport language="Odin" implementationClass="com.lasagnerd.odin.debugger.OdinDebuggerLanguageSupport"/>
+        <editorsExtension language="Odin" implementationClass="com.lasagnerd.odin.debugger.OdinDebuggerEditorsExtension" />
+        <lineBreakpointFileTypesProvider implementation="com.lasagnerd.odin.debugger.OdinLineBreakpointFileTypesProvider"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Odin debugging support using unofficial CIDR API. Only GDB supported (for now).

Setting breakpoints, stepping, creating watches, etc. (?) works.

TODO:

- [ ]  Build Odin executable with -debug symbols automatically
- [ ]  (Find out how to) Show all variables in current Scope.