### PR TITLE
fix: add newlines in type docs

### DIFF
--- a/modules/core/src/main/java/com/lasagnerd/odin/documentation/OdinDocumentationProvider.java
+++ b/modules/core/src/main/java/com/lasagnerd/odin/documentation/OdinDocumentationProvider.java
@@ -78,7 +78,7 @@ public class OdinDocumentationProvider extends AbstractDocumentationProvider {
         if (declaredType instanceof OdinProcedureLiteralType procedureLiteralType) {
             declarationText += procedureLiteralType.getProcedureDefinition().getProcedureSignature().getText();
         } else if (declaredType != null) {
-            declarationText += declaredType.getText();
+            declarationText += declaredType.getText().replaceAll("\n", "\n\n");
         } else if (declaration instanceof OdinConstantInitDeclaration constantInitializationStatement) {
             int index = constantInitializationStatement.getDeclaredIdentifiers().indexOf(declaredIdentifier);
             OdinExpression odinExpression = constantInitializationStatement.getExpressionList().get(index);


### PR DESCRIPTION
This adds newlines where they've been used in the declaration of a struct (or other type) when one tries to show documentation for the type.