### PR TITLE
fix: add newlines in procedure docs

### DIFF
--- a/modules/core/src/main/java/com/lasagnerd/odin/documentation/OdinDocumentationProvider.java
+++ b/modules/core/src/main/java/com/lasagnerd/odin/documentation/OdinDocumentationProvider.java
@@ -76,7 +76,7 @@ public class OdinDocumentationProvider extends AbstractDocumentationProvider {
 
         OdinType declaredType = OdinInsightUtils.getDeclaredType(declaredIdentifier);
         if (declaredType instanceof OdinProcedureLiteralType procedureLiteralType) {
-            declarationText += procedureLiteralType.getProcedureDefinition().getProcedureSignature().getText();
+            declarationText += procedureLiteralType.getProcedureDefinition().getProcedureSignature().getText().replaceAll("\n", "\n\n");
         } else if (declaredType != null) {
             declarationText += declaredType.getText().replaceAll("\n", "\n\n");
         } else if (declaration instanceof OdinConstantInitDeclaration constantInitializationStatement) {


### PR DESCRIPTION
This will correctly add newlines in procedure docs on hover, reflecting the source code they're pulled from.