### PR TITLE
update foojay-resolver and update the contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,16 +5,19 @@ We welcome contributions to improve the Odin IntelliJ Plugin! Follow the steps b
 1. **Fork this repository**  
    Create your own copy of this repository by clicking the "Fork" button in the top-right corner of this page.
 
-2. **Generate the Parser Code**  
+2. **Create generated sources folder**
+   Create the `modules/core/src/main/gen` folder, so the following steps guess their destination correctly.
+
+3. **Generate the Parser Code**  
    Navigate to the `Odin.bnf` file, right-click on it, and select **"Generate Parser Code"** or use the shortcut `Ctrl+Shift+G`.
 
-3. **Generate the Lexer Code**  
+4. **Generate the Lexer Code**  
    Navigate to the `Odin.flex` file, right-click on it, and select **"Run JFlex Generator"** or use the shortcut `Ctrl+Shift+G`.
  
-4. **Build**  
+5. **Build**  
    Execute `./gradlew build`
 
-5. **Create plugin**  
+6. **Create plugin**  
    Execute `$ ./gradlew plugin:buildPlugin`
    This will result in a zip file being created in `plugin/build/distributions`
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 rootProject.name = "odin-intellij"
 


### PR DESCRIPTION
hi, i'm trying to set up a dev environment for this plugin and i have this to contribute: :)

foojay-resolver update was needed to avoid the [Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU'](https://github.com/gradle/gradle/issues/35596) issue.

the codegen output folder (`modules/core/src/main/gen`) is not present in a fresh checkout, so the Ctrl+Shift+G will output into some other folder. I don't know if this can be configured explicitly, but at least if the folder is present, it generates into it, so the classes can be found by the compiler