### PR TITLE
Fix builtin symbol resolution when using Odin 2026-07

### DIFF
--- a/modules/core/src/main/java/com/lasagnerd/odin/codeInsight/sdk/OdinSdkServiceBase.java
+++ b/modules/core/src/main/java/com/lasagnerd/odin/codeInsight/sdk/OdinSdkServiceBase.java
@@ -206,6 +206,18 @@ public abstract class OdinSdkServiceBase implements OdinSdkService {
 
     private void setOdinOs(Map<OdinSymbol, EvOdinValue> valueMap) {
         TsOdinType odinOsType = getType("Odin_OS_Type");
+
+        EvEnumValue enumValue = getOdinOsEnumValue();
+        EvOdinValue value = new EvOdinValue(enumValue, odinOsType);
+        valueMap.put(getBuiltinSymbol("ODIN_OS"), value);
+
+        EvOdinValue stringValue = new EvOdinValue(enumValue
+                .getName()
+                .toLowerCase(), TsOdinBuiltInTypes.STRING);
+        valueMap.put(getBuiltinSymbol("ODIN_OS_STRING"), stringValue);
+    }
+
+    protected EvEnumValue getOdinOsEnumValue() {
         /*
         	    Unknown,
                 Windows,
@@ -220,21 +232,13 @@ public abstract class OdinSdkServiceBase implements OdinSdkService {
                 Freestanding,
          */
 
-        EvEnumValue enumValue;
         if (SystemInfo.isWindows) {
-            enumValue = new EvEnumValue("Windows", 1);
+            return new EvEnumValue("Windows", 1);
         } else if (SystemInfo.isLinux || SystemInfo.isMac) {
-            enumValue = new EvEnumValue("Linux", 3);
+            return new EvEnumValue("Linux", 3);
         } else {
-            enumValue = new EvEnumValue("Unknown", 0);
+            return new EvEnumValue("Unknown", 0);
         }
-        EvOdinValue value = new EvOdinValue(enumValue, odinOsType);
-        valueMap.put(getBuiltinSymbol("ODIN_OS"), value);
-
-        EvOdinValue stringValue = new EvOdinValue(enumValue
-                .getName()
-                .toLowerCase(), TsOdinBuiltInTypes.STRING);
-        valueMap.put(getBuiltinSymbol("ODIN_OS_STRING"), stringValue);
     }
 
     @Override

--- a/modules/core/src/main/java/com/lasagnerd/odin/lang/Odin.bnf
+++ b/modules/core/src/main/java/com/lasagnerd/odin/lang/Odin.bnf
@@ -332,7 +332,7 @@ directiveStatement                   ::= directive
 // Procedure overloading
 procedureGroupType                 ::= &procedureGroupHead PROC EOS_TOKEN? procedureGroupBlock {pin=2 methods=[getProcedureRefList]}
 procedureGroupBlock                ::= blockStart procedureGroupBody blockEnd
-procedureGroupBody                 ::= procedureRef (COMMA procedureRef)* (COMMA | EOS_TOKEN | &RBRACE)
+procedureGroupBody                 ::= procedureRef [WHERE expression] (COMMA procedureRef [WHERE expression])* (COMMA | EOS_TOKEN | &RBRACE)
 private procedureGroupHead         ::= PROC EOS_TOKEN? blockStart
 procedureRef                       ::= qualifiedType | simpleRefType
 

--- a/modules/plugin/src/test/java/com/lasagnerd/odin/lang/MockSdkService.java
+++ b/modules/plugin/src/test/java/com/lasagnerd/odin/lang/MockSdkService.java
@@ -3,6 +3,7 @@ package com.lasagnerd.odin.lang;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFileFactory;
+import com.lasagnerd.odin.codeInsight.evaluation.EvEnumValue;
 import com.lasagnerd.odin.codeInsight.imports.OdinImportService;
 import com.lasagnerd.odin.codeInsight.sdk.OdinSdkServiceBase;
 import com.lasagnerd.odin.lang.psi.OdinFile;
@@ -16,6 +17,13 @@ public class MockSdkService extends OdinSdkServiceBase {
     public MockSdkService(Project project, PsiFileFactory fileFactory) {
         super(project);
         this.fileFactory = fileFactory;
+    }
+
+    @Override
+    protected EvEnumValue getOdinOsEnumValue() {
+        // Test data (e.g. expression_eval.odin) is written assuming Windows,
+        // regardless of the OS the test suite actually runs on.
+        return new EvEnumValue("Windows", 1);
     }
 
     @Override

--- a/modules/plugin/src/test/testData/type_inference.odin
+++ b/modules/plugin/src/test/testData/type_inference.odin
@@ -271,6 +271,8 @@ circular_reference_test :: proc(render_commands: ^ClaryArray(RenderCommand)) {
     x := command.config
 }
 
+PROCEDURE_GROUP_WHERE :: true
+
 typeInference_procedureGroup :: proc() {
     PointDistinctAlias :: distinct Point
     PointAlias :: Point
@@ -309,7 +311,7 @@ typeInference_procedureGroup :: proc() {
 
     add_one :: proc {
         add_one_string,
-        add_one_integer,
+        add_one_integer where PROCEDURE_GROUP_WHERE,
         add_one_struct,
         add_one_distinct_alias,
         add_one_alias,


### PR DESCRIPTION
Thank you for your work on this plugin.

Today I updated Odin to the latest version and found that the plugin suddenly stopped detecting some of the builtin symbols (e.g. `new`, `panic`). This is the error I was getting every time I opened the project (trimmed for clarity):
```
java.lang.Throwable: File scope is null for file /home/michal/.local/share/odin/base/runtime/core_builtin.odin
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:375)
	at com.lasagnerd.odin.codeInsight.sdk.OdinSdkServiceBase.loadSymbols(OdinSdkServiceBase.java:503)
	at com.lasagnerd.odin.codeInsight.sdk.OdinSdkServiceBase.populateBuiltinSymbols(OdinSdkServiceBase.java:434)
	at com.lasagnerd.odin.codeInsight.sdk.OdinSdkServiceBase.loadBuiltinSymbols(OdinSdkServiceBase.java:143)
	at com.lasagnerd.odin.codeInsight.sdk.OdinSdkServiceImpl$1.lambda$run$0(OdinSdkServiceImpl.java:58)
```

When I opened this file in IntelliJ IDEA I noticed a single error
```
<eos> or OdinTokenType.COMMA expected, got '{'
```
at this part:
```
// `clear` will set the length of a passed dynamic array or map to `0`
@builtin
clear :: proc{
	clear_dynamic_array,
	clear_map where MAP_ENABLED,
	clear_fixed_capacity_dynamic_array,

	clear_soa_dynamic_array,
}
```

Turns out Odin 2026-07 has this `-bedrock` mode that disables some of the features, including `map`. This required disabling some overloads from the builtin functions, this is where the `where MAP_ENABLED` part comes from. I don't see any mention of this syntax in the docs or at the [grammar page](https://odin-lang.org/spec/grammar/), perhaps those were not updated yet.

I updated the BNF file and added that `where` construct to one of the overrides in the test data file that has procedure groups. The tests started failing when I reverted my BNF changes, so I guess while not very distinguished, the test data changes are enough.

There are 2 commits in this PR. The other one fixes running tests on Linux, the test data is written assuming `ODIN_OS` is `Windows`, so I allowed overriding its value for the tests. If you wish to have it done differently, I will remove those changes and open a separate issue.

I tested my changes on IntelliJ IDEA Ultimate. From what I can see the BNF probably needs some further adjustments to fix similar issues in the `base/intrinsics/intrinsics.odin` file, but it doesn't seem to affect regular workflow that much.